### PR TITLE
Show help for unsupported output extensions as well

### DIFF
--- a/deon/ethics_checklist.py
+++ b/deon/ethics_checklist.py
@@ -41,13 +41,15 @@ def main(checklist, format, output, clipboard, overwrite):
         if ext in EXTENSIONS.keys():
             output_format = EXTENSIONS[ext]
         else:
-            raise click.UsageError('Output requires a file name with a supported extension.')
+            with click.get_current_context() as ctx:
+                msg = 'Output requires a file name with a supported extension.\n'
+                raise click.ClickException(msg + ctx.get_help())
     elif format:
         if format in FORMATS:
             output_format = format
         else:
             with click.get_current_context() as ctx:
-                msg = "File format is not supported. Please See "
+                msg = "File format is not supported.\n"
                 raise click.ClickException(msg + ctx.get_help())
     else:
         output_format = 'markdown'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,7 @@ def test_output(checklist, tmpdir, test_format_configs):
 
     unsupported_output = tmpdir.join('test.doc')
     result = runner.invoke(main, ['--checklist', checklist, '--output', unsupported_output])
-    assert result.exit_code == 2
+    assert result.exit_code == 1
     assert "Error" in result.output
 
     temp_file_path = tmpdir.join('checklist.html')


### PR DESCRIPTION
#68 only showed help when an incorrect **format** was passed. We want this same behavior for incorrect **outputs** (i.e. unsupported file extension). 

Behavior now looks like this:
<img width="605" alt="screenshot 2018-09-10 10 11 49" src="https://user-images.githubusercontent.com/22667367/45312914-40f1d800-b4e2-11e8-9f38-82a0ff13ba12.png">
