### PR TITLE
small doc string update

### DIFF
--- a/deon/formats.py
+++ b/deon/formats.py
@@ -140,6 +140,7 @@ class JupyterNotebook(Markdown):
 
 
 class Html(Format):
+    """HTML template items"""
     template = """<h1>{title}</h1>
 <br/> <br/>
 {sections}
@@ -166,10 +167,6 @@ class Html(Format):
 """
 
     def write(self, filepath, overwrite=False):
-        """ If notebook does not exist (or `overwrite=True`), create a blank
-            notebook and add the checklist. Otherwise append a cell with a
-            horizontal rule and another cell with the checklist.
-        """
         filepath = Path(filepath)
 
         if filepath.exists() and not overwrite:


### PR DESCRIPTION
Remove an incorrect doc string on the write function of the Html class, add a small - consistent - doc string on the Html class before template information. This was done to slighly improve code quality, and keep the various formats consistent.