### PR TITLE
Use SafeLoader for PyYAML

### DIFF
--- a/deon/parser.py
+++ b/deon/parser.py
@@ -11,7 +11,7 @@ class Checklist(object):
     @classmethod
     def read(cls, filepath):
         with open(filepath, "r") as f:
-            data = yaml.load(f)
+            data = yaml.load(f, Loader=yaml.SafeLoader)
 
         title = data['title']
 

--- a/docs/render_templates.py
+++ b/docs/render_templates.py
@@ -49,7 +49,7 @@ def make_table_of_links():
     cl = Checklist.read(root / 'checklist.yml')
 
     with open(root / 'examples_of_ethical_issues.yml', 'r') as f:
-        refs = yaml.load(f)
+        refs = yaml.load(f, Loader=yaml.SafeLoader)
 
     refs_dict = dict()
     for r in refs:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ def test_checklist():
     c = Checklist.read(checklist_path)
 
     with open(checklist_path, "r") as f:
-        raw_parsed = yaml.load(f)
+        raw_parsed = yaml.load(f, Loader=yaml.SafeLoader)
 
     assert c.title == raw_parsed['title']
 


### PR DESCRIPTION
Specifies `yaml.SafeLoader` when using PyYAML to load .yml files. This restricts the object types that can be read in, which should be fine as deon typically expects only lists and strings from checklist files. 

Resolves two of the three issues in #75. 

Also resolves the following warning that users will see if using recent versions of PyYAML.

```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```