### PR TITLE
Jupyter and HTML render method changes. Resolves #34

### DIFF
--- a/deon/formats.py
+++ b/deon/formats.py
@@ -97,6 +97,14 @@ class Rst(Format):
    :target: http://deon.drivendata.org"""
 
 
+class JsonDict(dict):
+    def __str__(self):
+        return json.dumps(self)
+
+    def __repr__(self):
+        return json.dumps(self)
+
+
 class JupyterNotebook(Markdown):
     """ Jupyter notebook template items
     """
@@ -128,7 +136,7 @@ class JupyterNotebook(Markdown):
             'cells': [checklist_cell]
         }
 
-        return blank_jupyter_notebook
+        return JsonDict(blank_jupyter_notebook)
 
     def write(self, filepath, overwrite=False):
         """ If notebook does not exist (or `overwrite=True`), write new

--- a/deon/formats.py
+++ b/deon/formats.py
@@ -98,6 +98,7 @@ class Rst(Format):
 
 
 class JsonDict(dict):
+    """Suclass of dict with valid json string representation."""
     def __str__(self):
         return json.dumps(self)
 

--- a/deon/formats.py
+++ b/deon/formats.py
@@ -151,7 +151,7 @@ class JupyterNotebook(Markdown):
         if filepath.exists() and not overwrite:
             with open(filepath, 'r') as f:
                 existing_nbdata = json.load(f)
-            # Append cells into existing notebook'd vrlld
+            # Append cells into existing notebook's cells array
             existing_nbdata['cells'].append(self.append_delimiter)
             existing_nbdata['cells'].extend(nbdata['cells'])
             nbdata = existing_nbdata

--- a/deon/formats.py
+++ b/deon/formats.py
@@ -12,6 +12,10 @@ class Format(object):
         For text formats, simply override the templates
         below. For other formats, override `render`
         and `write`.
+
+        `render` should return an object whose string
+        representation is a fully valid document of
+        that format.
     """
     template = "{title}\n\n{sections}\n\n{docs_link}"
     append_delimiter = "\n\n"
@@ -104,11 +108,12 @@ class JupyterNotebook(Markdown):
     }
 
     def render(self):
-        """ Creates a cell with rendered Markdown of the
-            checklist.
+        """ Creates json for a valid blank Jupyter notebook with a cell
+            containing the rendered Markdown of the checklist.
         """
         text = super().render()
-        return {
+
+        checklist_cell = {
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -116,30 +121,31 @@ class JupyterNotebook(Markdown):
             ]
         }
 
+        blank_jupyter_notebook = {
+            'nbformat': 4,
+            'nbformat_minor': 2,
+            'metadata': {},
+            'cells': [checklist_cell]
+        }
+
+        return blank_jupyter_notebook
+
     def write(self, filepath, overwrite=False):
-        """ If notebook does not exist (or `overwrite=True`), create a blank
-            notebook and add the checklist. Otherwise append a cell with a
+        """ If notebook does not exist (or `overwrite=True`), write new
+            notebook with checklist. Otherwise append a cell with a
             horizontal rule and another cell with the checklist.
         """
+        nbdata = self.render()
+
         filepath = Path(filepath)
 
         if filepath.exists() and not overwrite:
             with open(filepath, 'r') as f:
-                nbdata = json.load(f)
-
-            nbdata['cells'].append(self.append_delimiter)
-        else:
-            # if new notebook, needs these properties
-            blank_jupyter_notebook = {
-                'nbformat': 4,
-                'nbformat_minor': 2,
-                'metadata': {},
-                'cells': []
-            }
-            nbdata = blank_jupyter_notebook
-
-        cell = self.render()
-        nbdata['cells'].append(cell)
+                existing_nbdata = json.load(f)
+            # Append cells into existing notebook'd vrlld
+            existing_nbdata['cells'].append(self.append_delimiter)
+            existing_nbdata['cells'].extend(nbdata['cells'])
+            nbdata = existing_nbdata
 
         with open(filepath, "w") as f:
             json.dump(nbdata, f)
@@ -181,21 +187,31 @@ class Html(Format):
 </html>
 """
 
+    def render(self):
+        """ Create a new blank HTML document with checklist as the body.
+            Returned as a BeautifulSoup object.
+        """
+        rendered_html = self.doc_template.format(text=super().render())
+        soup = BeautifulSoup(rendered_html, 'html.parser')
+        # string representation of soup is the raw html, so we can return it
+        return soup
+
     def write(self, filepath, overwrite=False):
+        """ If html document does not exist (or `overwrite=True`), write new
+            html file with checklist. Otherwise append checklist to the end of
+            the body of the existing html file.
+        """
         filepath = Path(filepath)
 
-        if filepath.exists() and not overwrite:
-            # insert at end of body
-            checklist = self.render()
+        soup = self.render()
 
+        if filepath.exists() and not overwrite:
             with open(filepath, "r") as f:
-                soup = BeautifulSoup(f, 'html.parser')
+                existing_soup = BeautifulSoup(f, 'html.parser')
 
             # add checklist to end of body
-            soup.body.append(BeautifulSoup(checklist, 'html.parser'))
-        else:
-            rendered_html = self.doc_template.format(text=self.render())
-            soup = BeautifulSoup(rendered_html, 'html.parser')
+            existing_soup.body.contents.extend(soup.body.contents)
+            soup = existing_soup
 
         text = soup.prettify()
 

--- a/tests/assets.py
+++ b/tests/assets.py
@@ -46,7 +46,12 @@ B. Second section
 
 *Data Science Ethics Checklist generated with* `deon <http://deon.drivendata.org>`_."""
 
-known_good_jupyter = ({'cell_type': 'markdown',
+known_good_jupyter = ({
+    'nbformat': 4,
+    'nbformat_minor': 2,
+    'metadata': {},
+    'cells': [
+        {'cell_type': 'markdown',
                        'metadata': {},
                        'source': ['# My Checklist\n',
                                   '\n',
@@ -62,7 +67,9 @@ known_good_jupyter = ({'cell_type': 'markdown',
                                   '\n',
                                   "*Data Science Ethics Checklist generated with [deon](http://deon.drivendata.org).*"
                                   "\n"
-                                  ]})
+                                  ]}
+    ]
+})
 
 known_good_html = """<html>
  <body>

--- a/tests/test_deon.py
+++ b/tests/test_deon.py
@@ -17,7 +17,7 @@ def test_output(checklist, tmpdir, test_format_configs):
         else:
             with open(temp_file_path, 'r') as f:
                 nbdata = json.load(f)
-            assert nbdata['cells'][0] == known_good
+            assert nbdata == known_good
 
     unsupported_output = tmpdir.join('test.doc')
     with pytest.raises(deon.ExtensionException):
@@ -50,7 +50,7 @@ def test_overwrite(checklist, tmpdir, test_format_configs):
         else:
             with open(temp_file_path, 'r') as f:
                 nbdata = json.load(f)
-            assert nbdata['cells'][0] == known_good
+            assert nbdata == known_good
 
 
 def test_clipboard(checklist, tmpdir, test_format_configs):

--- a/tests/test_deon.py
+++ b/tests/test_deon.py
@@ -1,4 +1,5 @@
 import json
+from bs4 import BeautifulSoup
 
 import pytest
 import xerox
@@ -57,5 +58,16 @@ def test_clipboard(checklist, tmpdir, test_format_configs):
     for frmt, _, known_good in test_format_configs:
         deon.create(checklist, frmt, None, True, False)
 
-        if frmt != 'html':  # full doc for html not returned with format
+        if frmt == 'jupyter':
+            # Jupyter requires json.dumps for double-quoting
+            assert xerox.paste() == json.dumps(known_good)
+            # Check that it's also valid json
+            assert json.loads(xerox.paste()) == known_good
+        elif frmt == 'html':
+            # Ensure valid html
+            clipboard_html = BeautifulSoup(xerox.paste(), 'html.parser')
+            known_good_html = BeautifulSoup(known_good, 'html.parser')
+            # Check html are equivalent ignoring formatting
+            assert clipboard_html.prettify() == known_good_html.prettify()
+        else:
             assert xerox.paste() == str(known_good)

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,5 +1,6 @@
 from pytest import fixture
 import json
+from bs4 import BeautifulSoup
 
 from deon.parser import Checklist, Section, Line
 from deon.formats import Format, Markdown, JupyterNotebook, Html, Rst
@@ -131,16 +132,25 @@ def test_html(checklist, tmpdir):
     temp_file_path = tmpdir.join('test.html')
     h.write(temp_file_path)
     with open(temp_file_path, 'r') as tempf:
-        assert tempf.read() == known_good
+        # Read back in bs4 to ensure valid html
+        temp_soup = BeautifulSoup(tempf, 'html.parser')
+        known_good_soup = BeautifulSoup(known_good, 'html.parser')
+        assert temp_soup.prettify() == known_good_soup.prettify()
 
     # append to existing file
     with open(temp_file_path, 'w') as tempf:
         tempf.write(existing_text)
     h.write(temp_file_path, overwrite=False)
     with open(temp_file_path, 'r') as tempf:
-        assert tempf.read() == inserted_known_good
+        # Read back in bs4 to ensure valid html
+        temp_soup = BeautifulSoup(tempf, 'html.parser')
+        known_good_soup = BeautifulSoup(inserted_known_good, 'html.parser')
+        assert temp_soup.prettify() == known_good_soup.prettify()
 
     # overwrite existing file
     h.write(temp_file_path, overwrite=True)
     with open(temp_file_path, 'r') as tempf:
-        assert tempf.read() == known_good
+        # Read back in bs4 to ensure valid html
+        temp_soup = BeautifulSoup(tempf, 'html.parser')
+        known_good_soup = BeautifulSoup(known_good, 'html.parser')
+        assert temp_soup.prettify() == known_good_soup.prettify()

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -102,14 +102,14 @@ def test_jupyter(checklist, tmpdir):
     j.write(temp_file_path)
     with open(temp_file_path, 'r') as f:
         nbdata = json.load(f)
-    assert nbdata['cells'] == [known_good]
+    assert nbdata == known_good
 
     # append to existing file
     j.write(temp_file_path, overwrite=False)
     with open(temp_file_path, 'r') as f:
         nbdata = json.load(f)
     assert len(nbdata['cells']) == 3
-    assert nbdata['cells'][0] == known_good
+    assert nbdata['cells'][0] == known_good['cells'][0]
     assert nbdata['cells'][1] == JupyterNotebook.append_delimiter
     assert nbdata['cells'][0] == nbdata['cells'][-1]
 
@@ -118,7 +118,7 @@ def test_jupyter(checklist, tmpdir):
     with open(temp_file_path, 'r') as f:
         nbdata = json.load(f)
     print(json.dumps(nbdata, indent=4))
-    assert nbdata['cells'] == [known_good]
+    assert nbdata == known_good
 
 
 def test_html(checklist, tmpdir):


### PR DESCRIPTION
- Changed `render` methods for `JupyterNotebook` and `Html` format classes to return valid full document representations. This makes their behavior more consistent with the other formats and resolves #34.
- `render` method for `JupyterNotebook` now returns a subclass of dict whose string representation has double-quotes, rather than single-quotes of regular dicts. This is needed to return valid json. Previously, using the clipboard option with the jupyter format not only didn't return a full document, but also did not return valid json.
- Updated tests for jupyter and html formats to check for valid output by loading with `json` and `BeautifulSoup`, respectively.
