### PR TITLE
Add Travis CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,22 @@ jobs:
     - name: "Python 3.6 on Linux"
       os: linux
       python: 3.6
-      script:
+      script:       # Additionally test docs
+        - make test
         - make examples
         - make docs
     - name: "Python 3.8 on Linux"
       os: linux
       python: 3.8
-    - name: "Python 3 stable on macOS"
+    - name: "Python 3.6 on macOS"
       os: osx
       language: shell       # 'language: python' isn't directly supported by Travis CI for osx
+      addons:
+        homebrew:
+          packages: python3
       before_install:
-        - brew upgrade python
+        - python3 -m venv "$HOME/venv"
+        - source "$HOME/venv/bin/activate"
     - name: "Python 3.8 on Windows"
       os: windows
       language: shell       # 'language: python' isn't directly supported by Travis CI for windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+
+# https://docs.travis-ci.com/user/languages/python#running-python-tests-on-multiple-operating-systems
+jobs:
+  include:
+    - name: "Python 3.6 on Linux"
+      os: linux
+      python: 3.6
+    - name: "Python 3.8 on Linux"
+      os: linux
+      python: 3.8
+    - name: "Python 3.8 on macOS"
+      os: osx
+      language: shell       # 'language: python' isn't directly supported by Travis CI for osx
+      before_install:
+        - brew install python@3.8
+    - name: "Python 3.8 on Windows"
+      os: windows
+      language: shell       # 'language: python' isn't directly supported by Travis CI for windows
+      before_install:
+        - choco install python3 --version 3.8
+      env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
+
+install:
+  - pip install -r dev-requirements.txt
+
+script:
+  - make test && make examples && make docs
+
+# Build fails as soon as any job fails
+# https://blog.travis-ci.com/2013-11-27-fast-finishing-builds
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ jobs:
     - name: "Python 3.8 on Linux"
       os: linux
       python: 3.8
-    - name: "Python 3.8 on macOS"
+    - name: "Python 3 stable on macOS"
       os: osx
       language: shell       # 'language: python' isn't directly supported by Travis CI for osx
       before_install:
-        - brew install python@3.8
+        - brew install python
     - name: "Python 3.8 on Windows"
       os: windows
       language: shell       # 'language: python' isn't directly supported by Travis CI for windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,12 @@ jobs:
     - name: "Python 3 stable on macOS"
       os: osx
       language: shell       # 'language: python' isn't directly supported by Travis CI for osx
-      before_install:
-        - brew install python
     - name: "Python 3.8 on Windows"
       os: windows
       language: shell       # 'language: python' isn't directly supported by Travis CI for windows
       before_install:
         - choco install python3 --version 3.8
+        - choco install make
       env: PATH=/c/Python38:/c/Python38/Scripts:$PATH
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ jobs:
     - name: "Python 3.6 on Linux"
       os: linux
       python: 3.6
+      script:
+        - make examples
+        - make docs
     - name: "Python 3.8 on Linux"
       os: linux
       python: 3.8
     - name: "Python 3 stable on macOS"
       os: osx
       language: shell       # 'language: python' isn't directly supported by Travis CI for osx
+      before_install:
+        - brew upgrade python
     - name: "Python 3.8 on Windows"
       os: windows
       language: shell       # 'language: python' isn't directly supported by Travis CI for windows
@@ -24,7 +29,7 @@ install:
   - pip install -r dev-requirements.txt
 
 script:
-  - make test && make examples && make docs
+  - make test
 
 # Build fails as soon as any job fails
 # https://blog.travis-ci.com/2013-11-27-fast-finishing-builds

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ docs: render_markdown
 	cd docs && mkdocs build
 
 test: lint
-	py.test -vv
+	pytest -vv
 
 lint:
 	flake8 .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@
 
 -e .
 
-flake8==3.5.0
+flake8
 jinja2==2.10.1
 mkdocs==1.0.1
 git+https://github.com/drivendataorg/mkdocs-alabaster.git#egg=mkdocs-alabaster


### PR DESCRIPTION
Add testing on Travis CI for Linux, macOS, and Windows. Resolves #76.  