### PR TITLE
Add link to wiki page instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
 
 We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+
+We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 
 ## Related tools
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -231,7 +231,7 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
 
 We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -231,7 +231,9 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+
+We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 
 ## Related tools
 

--- a/docs/md_templates/_common_body.tpl
+++ b/docs/md_templates/_common_body.tpl
@@ -168,7 +168,7 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
 
 We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 

--- a/docs/md_templates/_common_body.tpl
+++ b/docs/md_templates/_common_body.tpl
@@ -168,7 +168,9 @@ We're excited to see so many articles popping up on data ethics! The short list 
 
 ## Where things have gone wrong
 
-To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in process ethics discussions may have helped provide a course correction.
+To make the ideas contained in the checklist more concrete, we've compiled [examples](http://deon.drivendata.org/examples/) of times when things have gone wrong. They're paired these with the checklist questions to help illuminate where in the process ethics discussions may have helped provide a course correction.
+
+We welcome contributions! Follow [these instructions](https://github.com/drivendataorg/deon/wiki/Add-a-new-item-to-the-examples-table) to add an example.
 
 ## Related tools
 


### PR DESCRIPTION
- add link to wiki instructions to adding an example
- bonus: typo fix