### PR TITLE
Fix Flake8 lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,17 +120,22 @@ Usage: deon [OPTIONS]
 Options:
   -l, --checklist PATH  Override default checklist file with a path to a custom
                         checklist.yml file.
+
   -f, --format TEXT     Output format. Default is "markdown". Can be one of
                         [ascii, html, jupyter, markdown, rmarkdown, rst].
                         Ignored and file extension used if --output is passed.
+
   -o, --output PATH     Output file path. Extension can be one of [.txt, .html,
                         .ipynb, .md, .rmd, .rst]. The checklist is appended if
                         the file exists.
+
   -w, --overwrite       Overwrite output file if it exists. Default is False,
                         which will append to existing file.
+
   -m, --multicell       For use with Jupyter format only. Write checklist with
                         multiple cells, one item per cell. Default is False,
                         which will write the checklist in a single cell.
+
   --help                Show this message and exit.
 
 ```

--- a/deon/formats.py
+++ b/deon/formats.py
@@ -41,9 +41,9 @@ class Format(object):
             rendered_lines = self.line_delimiter.join(
                 [
                     self.line_template.format(
-                        line_id=l.line_id, line_summary=l.line_summary, line=l.line
+                        line_id=line.line_id, line_summary=line.line_summary, line=line.line
                     )
-                    for l in section.lines
+                    for line in section.lines
                 ]
             )
 
@@ -137,7 +137,7 @@ class JupyterNotebook(Markdown):
         checklist_cell = {
             "cell_type": "markdown",
             "metadata": {},
-            "source": [l + "\n" for l in text.split("\n")],
+            "source": [line + "\n" for line in text.split("\n")],
         }
 
         blank_jupyter_notebook = {

--- a/deon/parser.py
+++ b/deon/parser.py
@@ -18,7 +18,9 @@ class Checklist(object):
 
         sections = []
         for s in data["sections"]:
-            lines = [Line(l["line_id"], l["line_summary"], l["line"]) for l in s["lines"]]
+            lines = [
+                Line(line["line_id"], line["line_summary"], line["line"]) for line in s["lines"]
+            ]
             sections.append(Section(s["title"], s["section_id"], lines))
 
         return cls(title, sections)

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -113,17 +113,22 @@ Usage: deon [OPTIONS]
 Options:
   -l, --checklist PATH  Override default checklist file with a path to a custom
                         checklist.yml file.
+
   -f, --format TEXT     Output format. Default is "markdown". Can be one of
                         [ascii, html, jupyter, markdown, rmarkdown, rst].
                         Ignored and file extension used if --output is passed.
+
   -o, --output PATH     Output file path. Extension can be one of [.txt, .html,
                         .ipynb, .md, .rmd, .rst]. The checklist is appended if
                         the file exists.
+
   -w, --overwrite       Overwrite output file if it exists. Default is False,
                         which will append to existing file.
+
   -m, --multicell       For use with Jupyter format only. Write checklist with
                         multiple cells, one item per cell. Default is False,
                         which will write the checklist in a single cell.
+
   --help                Show this message and exit.
 
 ```

--- a/docs/render_templates.py
+++ b/docs/render_templates.py
@@ -67,10 +67,10 @@ def make_table_of_links():
         row = section_title_template.format(section_title=s.title)
         formatted_rows.append(row)
 
-        for l in s.lines:
+        for line in s.lines:
             # create bulleted list of links for each checklist item in that section
             bulleted_list = []
-            for link in refs_dict[l.line_id]:
+            for link in refs_dict[line.line_id]:
                 text = link["text"]
                 url = link["url"]
                 bullet_hyperlink = f"<li>[{text}]({url})</li>"
@@ -78,9 +78,9 @@ def make_table_of_links():
             formatted_bullets = "".join(bulleted_list)
 
             row = line_template.format(
-                line_id=l.line_id,
-                line_summary=l.line_summary,
-                line=l.line,
+                line_id=line.line_id,
+                line_summary=line.line_summary,
+                line=line.line,
                 row_text=f"<ul>{formatted_bullets}</ul>",
             )
             formatted_rows.append(row)


### PR DESCRIPTION
Apparently flake8 or pyflakes recently had a change that caused E741 to get picked up. This is causing failures on master that we didn't see before because we haven't run any builds in a month. I added a weekly job to Travis on master, so in the future we'll find out about these sooner automatically. 

This PR:

- Fixes E741 issues, fixing the failing build on master.
- Introduces newlines between help options in docs, due to an update to click as of v7.1 (2020-03-09)