### PR TITLE
add-main-call

### DIFF
--- a/deon/__main__.py
+++ b/deon/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/deon/__main__.py
+++ b/deon/__main__.py
@@ -1,4 +1,4 @@
 from .cli import main
 
 if __name__ == "__main__":
-    main()
+    main(prog_name='python -m deon')

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -19,7 +19,7 @@ extra:
   extra_nav_links:
     Markdown: https://github.com/drivendataorg/deon/blob/master/examples/ethics.md
     HTML: https://github.com/drivendataorg/deon/blob/master/examples/ethics.html
-    Jupyter Notebok: https://github.com/drivendataorg/deon/blob/master/examples/ethics.ipynb
+    Jupyter Notebook: https://github.com/drivendataorg/deon/blob/master/examples/ethics.ipynb
     RST: https://github.com/drivendataorg/deon/blob/master/examples/ethics.rst
     Text: https://github.com/drivendataorg/deon/blob/master/examples/ethics.txt
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
 import subprocess
+import itertools as it
 from click.testing import CliRunner
 
 import assets
@@ -38,7 +39,13 @@ def test_cli_output(runner, checklist, tmpdir, test_format_configs, arg):
     assert temp_file_path.read() == assets.known_good_html
 
 
-@pytest.mark.parametrize("call", [["deon"], ["python", "-m",  "deon"]])
-def test_base_call_no_error(call):
-    status = subprocess.run(call)
+@pytest.mark.parametrize(
+    "call,format",
+    it.product(
+        [["deon"], ["python", "-m", "deon"]],
+        ["ascii", "html", "jupyter", "markdown", "rmarkdown", "rst"],
+    ),
+)
+def test_base_call_no_error(call, format):
+    status = subprocess.run(call + ["--format", format])
     assert status.returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from click.testing import CliRunner
 
 import assets
@@ -35,3 +36,9 @@ def test_cli_output(runner, checklist, tmpdir, test_format_configs, arg):
     result = runner.invoke(main, ["--checklist", checklist, arg, temp_file_path])
     assert result.exit_code == 0
     assert temp_file_path.read() == assets.known_good_html
+
+
+@pytest.mark.parametrize("call", [["deon"], ["python", "-m",  "deon"]])
+def test_base_call_no_error(call):
+    status = subprocess.run(call)
+    assert status.returncode == 0


### PR DESCRIPTION
I've added a `__main__.py` file. This ensures that you can also call deon via; 

```
python -m deon
```

I didn't add a test but I could add a test that checks via `subprocess` that the main call works. 

I also spotted a spelling error on the website, fixed that too. 