### PR TITLE
Add codecov report to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
 
@@ -34,6 +34,13 @@ jobs:
     - name: Lint and Test Package
       run: |
         make test
+
+    - name: Upload coverage to codecov
+      uses: codecov/codecov-action@v1
+      with:
+        file: ./coverage.xml
+        fail_ci_if_error: true
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8 }}
 
     - name: Test Building Docs
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,144 @@
-*.egg-info
-__pycache__/
-.pytest_cache/
-.ipynb_checkpoints/
 docs/site/
-dist/
 .vscode
-htmlcov
-.coverage
 .idea
+
+### FROM https://github.com/github/gitignore/blob/master/Python.gitignore ###
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <a href="http://deon.drivendata.org/"><img src="https://s3.amazonaws.com/drivendata-public-assets/deon.png" width=200/></a>
 
-[![tests](https://github.com/drivendataorg/deon/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/deon/actions?query=workflow%3A%22tests%22+branch%3Amaster) [![PyPI](https://img.shields.io/pypi/v/deon.svg)](https://pypi.org/project/deon/) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/deon.svg)](https://anaconda.org/conda-forge/deon)
+[![tests](https://github.com/drivendataorg/deon/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/deon/actions?query=workflow%3A%22tests%22+branch%3Amaster) [![codecov](https://codecov.io/gh/drivendataorg/deon/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/deon) [![PyPI](https://img.shields.io/pypi/v/deon.svg)](https://pypi.org/project/deon/) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/deon.svg)](https://anaconda.org/conda-forge/deon)
 
  > [Read more about `deon` on the project homepage](http://deon.drivendata.org/)
 

--- a/docs/md_templates/readme.tpl
+++ b/docs/md_templates/readme.tpl
@@ -1,6 +1,6 @@
 <a href="http://deon.drivendata.org/"><img src="https://s3.amazonaws.com/drivendata-public-assets/deon.png" width=200/></a>
 
-[![tests](https://github.com/drivendataorg/deon/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/deon/actions?query=workflow%3A%22tests%22+branch%3Amaster) [![PyPI](https://img.shields.io/pypi/v/deon.svg)](https://pypi.org/project/deon/) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/deon.svg)](https://anaconda.org/conda-forge/deon)
+[![tests](https://github.com/drivendataorg/deon/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/deon/actions?query=workflow%3A%22tests%22+branch%3Amaster) [![codecov](https://codecov.io/gh/drivendataorg/deon/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/deon) [![PyPI](https://img.shields.io/pypi/v/deon.svg)](https://pypi.org/project/deon/) [![Conda Version](https://img.shields.io/conda/vn/conda-forge/deon.svg)](https://anaconda.org/conda-forge/deon)
 
  > [Read more about `deon` on the project homepage](http://deon.drivendata.org/)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths = tests
-addopts = --cov=. tests --cov-report=term --cov-report=html
+addopts = --cov=. --cov-report=term --cov-report=html --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,9 @@ description-file = README.md
 [flake8]
 ignore = E501, W503
 max-line-length = 99
+
+[tool:pytest]
+collect_ignore = ['setup.py']
+
+[coverage:report]
+include = deon/**.py


### PR DESCRIPTION
- Add codecov reporting to CI
- Configure coverage to only report coverage for deon package modules
- Fix pytest configuration that runs all tests even when you try to specify an individual test
- Copied in GitHub's generic .gitignore for Python