### PR TITLE
Add `dist` make command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         cat VERSION
         echo "::set-output name=version::$(cat VERSION)"
-        make package
+        make dist
 
     - name: Publish to Test PyPI
       uses: pypa/gh-action-pypi-publish@v1.3.0

--- a/Makefile
+++ b/Makefile
@@ -47,12 +47,10 @@ clean: clean_pycache
 package: build clean
 	python setup.py sdist
 
-distribute_pypitest: package
-	twine upload --repository pypitest dist/*.tar.gz
-
-distribute_pypi: package
-	twine upload --repository pypi dist/*.tar.gz
-
+dist: clean ## builds source and wheel package
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
 
 #################################################################################
 # Self Documenting Commands                                                                #

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ clean: clean_pycache
 	rm -rf dist
 	rm -rf deon.egg-info
 
-package: build clean
-	python setup.py sdist
-
 dist: clean ## builds source and wheel package
 	python setup.py sdist
 	python setup.py bdist_wheel

--- a/README.md
+++ b/README.md
@@ -120,23 +120,28 @@ Usage: deon [OPTIONS]
 
   Easily create an ethics checklist for your data science project.
 
-  The checklist will be printed to standard output by default. Use the --output
-  option to write to a file instead.
+  The checklist will be printed to standard output by default. Use the
+  --output option to write to a file instead.
 
 Options:
   -l, --checklist PATH  Override default checklist file with a path to a custom
                         checklist.yml file.
+
   -f, --format TEXT     Output format. Default is "markdown". Can be one of
                         [ascii, html, jupyter, markdown, rmarkdown, rst].
                         Ignored and file extension used if --output is passed.
+
   -o, --output PATH     Output file path. Extension can be one of [.txt, .html,
                         .ipynb, .md, .rmd, .rst]. The checklist is appended if
                         the file exists.
+
   -w, --overwrite       Overwrite output file if it exists. Default is False,
                         which will append to existing file.
+
   -m, --multicell       For use with Jupyter format only. Write checklist with
                         multiple cells, one item per cell. Default is False,
                         which will write the checklist in a single cell.
+
   --help                Show this message and exit.
 
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ pytest==3.6.4
 pymdown-extensions==5.0
 twine==1.11.0
 pytest-cov==2.6.0
+wheel

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -113,23 +113,28 @@ Usage: deon [OPTIONS]
 
   Easily create an ethics checklist for your data science project.
 
-  The checklist will be printed to standard output by default. Use the --output
-  option to write to a file instead.
+  The checklist will be printed to standard output by default. Use the
+  --output option to write to a file instead.
 
 Options:
   -l, --checklist PATH  Override default checklist file with a path to a custom
                         checklist.yml file.
+
   -f, --format TEXT     Output format. Default is "markdown". Can be one of
                         [ascii, html, jupyter, markdown, rmarkdown, rst].
                         Ignored and file extension used if --output is passed.
+
   -o, --output PATH     Output file path. Extension can be one of [.txt, .html,
                         .ipynb, .md, .rmd, .rst]. The checklist is appended if
                         the file exists.
+
   -w, --overwrite       Overwrite output file if it exists. Default is False,
                         which will append to existing file.
+
   -m, --multicell       For use with Jupyter format only. Write checklist with
                         multiple cells, one item per cell. Default is False,
                         which will write the checklist in a single cell.
+
   --help                Show this message and exit.
 
 ```


### PR DESCRIPTION
PR #129 uses `make dist` to build the distribution and test installation, but no corresponding make command existed. This PR adds the required make command and removes the unused package ones. 

Also incorporates minor formatting changes.

Closes #132 