### PR TITLE
Add quickstart above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@
 
 The conversation about ethics in data science, machine learning, and AI is increasingly important. The goal of `deon` is to push that conversation forward and provide concrete, actionable reminders to the developers that have influence over how data science gets done.
 
+# Quickstart
+
+You only need two lines of code to get started!
+
+First, install deon:
+
+```
+$ pip install deon
+```
+
+Then, write out the [default checklist](#default-checklist) to a markdown file called `ETHICS.md`:
+
+```
+$ deon -o ETHICS.md
+```
+
+Dig into the checklist questions to identify and navigate the ethical considerations in your data science project.
+
+For more configuration details, see the sections on [command line options](#command-line-options), [supported output file types](#supported-file-types), and [custom checklists](#custom-checklists).
+
 # Background and perspective
 
 We have a particular perspective with this package that we will use to make decisions about contributions, issues, PRs, and other maintenance and support activities.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -14,6 +14,26 @@
 
 The conversation about ethics in data science, machine learning, and AI is increasingly important. The goal of `deon` is to push that conversation forward and provide concrete, actionable reminders to the developers that have influence over how data science gets done.
 
+# Quickstart
+
+You only need two lines of code to get started!
+
+First, install deon:
+
+```
+$ pip install deon
+```
+
+Then, write out the [default checklist](#default-checklist) to a markdown file called `ETHICS.md`:
+
+```
+$ deon -o ETHICS.md
+```
+
+Dig into the checklist questions to identify and navigate the ethical considerations in your data science project.
+
+For more configuration details, see the sections on [command line options](#command-line-options), [supported output file types](#supported-file-types), and [custom checklists](#custom-checklists).
+
 # Background and perspective
 
 We have a particular perspective with this package that we will use to make decisions about contributions, issues, PRs, and other maintenance and support activities.

--- a/docs/md_templates/_common_body.tpl
+++ b/docs/md_templates/_common_body.tpl
@@ -12,6 +12,26 @@
 
 The conversation about ethics in data science, machine learning, and AI is increasingly important. The goal of `deon` is to push that conversation forward and provide concrete, actionable reminders to the developers that have influence over how data science gets done.
 
+# Quickstart
+
+You only need two lines of code to get started!
+
+First, install deon:
+
+```
+$ pip install deon
+```
+
+Then, write out the [default checklist](#default-checklist) to a markdown file called `ETHICS.md`:
+
+```
+$ deon -o ETHICS.md
+```
+
+Dig into the checklist questions to identify and navigate the ethical considerations in your data science project.
+
+For more configuration details, see the sections on [command line options](#command-line-options), [supported output file types](#supported-file-types), and [custom checklists](#custom-checklists).
+
 # Background and perspective
 
 We have a particular perspective with this package that we will use to make decisions about contributions, issues, PRs, and other maintenance and support activities.


### PR DESCRIPTION
Currently, we have a lot of text before we get to the usage instructions on deon.drivendata.org.

This adds an upfront quickstart section so people can get going right away.

Closes #80 