### PR TITLE
Unpin all dev reqs

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,10 +5,10 @@
 flake8
 black
 jinja2
-mkdocs==1.2.4
+mkdocs
 git+https://github.com/drivendataorg/mkdocs-alabaster.git#egg=mkdocs-alabaster
-pytest==3.6.4
-pymdown-extensions==5.0
-twine==1.11.0
-pytest-cov==2.6.0
+pytest
+pymdown-extensions
+twine
+pytest-cov
 wheel


### PR DESCRIPTION
Free all of our dev requirements up to the latest versions, especially with regards to mkdocs-related dependencies. 

I don't think we really have strong reasons to keep anything pinned right now. 

- Closes #150 