### PR TITLE
Update Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 99
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.py
+++ b/setup.py
@@ -44,13 +44,16 @@ setup(
     license="MIT",
     packages=setuptools.find_packages(),
     keywords=["data science", "ethics", "checklist"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=requirements,
     entry_points={"console_scripts": ["deon=deon.cli:main"]},
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         # Indicate who your project is intended for
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
Tests were failing because 3.6 is EOL.

Remove 3.6 support and add 3.10.

Closes #156 
Closes #155