### PR TITLE
Fix HTML appending for beautifulsoup4 >= 4.12.1

### DIFF
--- a/deon/formats.py
+++ b/deon/formats.py
@@ -250,7 +250,7 @@ class Html(Format):
                 existing_soup = BeautifulSoup(f, "html.parser")
 
             # add checklist to end of body
-            existing_soup.body.contents.extend(soup.body.contents)
+            existing_soup.body.extend(soup.body.contents)
             soup = existing_soup
 
         text = soup.prettify()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-beautifulsoup4>=4.6.1
+beautifulsoup4>=4.7.0
 click>=6.7
 pyyaml>=3.13


### PR DESCRIPTION
Changes `Html.write` in the append case to use the `extend` method on the Beautiful Soup tag directly, rather than `extend` on the `contents` list. Beautiful Soup's documentation says that modifying `contents` is not the intended way to modify soups. See [this comment](https://github.com/drivendataorg/deon/issues/161#issuecomment-1510481639) for references.

The `Tag.extend` method was added in version 4.7.0, so this PR also bumps up the dependency floor to that. 

Closes #161 