### PR TITLE
GitHub Actions maintenance

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,10 +12,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.11 with uv
+      uses: drivendataorg/setup-python-uv-action@v1
       with:
-        python-version: 3.8
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        uv pip install -r dev-requirements.txt
 
     - name: Build examples and docs
       run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.8
       uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,14 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+    - name: Set up Python 3.11 with uv
+      uses: drivendataorg/setup-python-uv-action@v1
       with:
-        python-version: 3.7
+        python-version: 3.11
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install -r dev-requirements.txt
+        uv pip install -r dev-requirements.txt
 
     - name: Build package
       id: build_package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,11 +76,11 @@ jobs:
             PYTHON_BIN=bin/python
           fi
           echo "=== Testing wheel installation ==="
-          uv virtualenv .venv-whl
+          uv virtualenv .venv-whl --seed
           uv pip install dist/deon-*.whl --python=.venv-whl/$PYTHON_BIN
           .venv-whl/$PYTHON_BIN -m deon --help
           echo "=== Testing source installation ==="
-          uv virtualenv .venv-sdist
+          uv virtualenv .venv-sdist --seed
           uv pip install dist/deon-*.tar.gz --python=.venv-sdist/$PYTHON_BIN
           .venv-sdist/$PYTHON_BIN -m deon --help
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - name: Set up Python 3.11 with uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
-          python-version: 3.8
+          python-version: 3.11
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r dev-requirements.txt
+          uv pip install -r dev-requirements.txt
 
       - name: Lint package
         run: |
@@ -40,21 +39,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
 
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }} with uv
+        uses: drivendataorg/setup-python-uv-action@v1
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r dev-requirements.txt
+          uv pip install -r dev-requirements.txt
 
       - name: Test Package
         run: |
@@ -78,14 +76,12 @@ jobs:
             PYTHON_BIN=bin/python
           fi
           echo "=== Testing wheel installation ==="
-          python -m venv .venv-whl
-          .venv-whl/$PYTHON_BIN -m pip install --upgrade pip
-          .venv-whl/$PYTHON_BIN -m pip install dist/deon-*.whl
+          uv virtualenv .venv-whl
+          uv pip install dist/deon-*.whl --python=.venv-whl/$PYTHON_BIN
           .venv-whl/$PYTHON_BIN -m deon --help
           echo "=== Testing source installation ==="
-          python -m venv .venv-sdist
-          .venv-sdist/$PYTHON_BIN -m pip install --upgrade pip
-          .venv-sdist/$PYTHON_BIN -m pip install dist/deon-*.tar.gz --force-reinstall
+          uv virtualenv .venv-sdist
+          uv pip install dist/deon-*.tar.gz --python=.venv-sdist/$PYTHON_BIN
           .venv-sdist/$PYTHON_BIN -m deon --help
 
       - name: Test Building Docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
       - name: Build distribution and test installation
         shell: bash
         run: |
+          uv pip install setuptools  # Need this because we still use setup.py
           make dist
           if [[ ${{ matrix.os }} == "windows-latest" ]]; then
             PYTHON_BIN=Scripts/python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
@@ -44,7 +44,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
           make test
 
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
           uv pip install setuptools  # Need this because we still use setup.py
           make dist
           if [[ ${{ matrix.os }} == "windows-latest" ]]; then
-            PYTHON_BIN=Scripts/python
+            PYTHON_BIN=Scripts/python.exe
           else
             PYTHON_BIN=bin/python
           fi

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 reqs:
 	pip install -r dev-requirements.txt
 
-examples: reqs
+examples:
 	deon --output examples/ethics.md --overwrite
 	deon --output examples/ethics.ipynb --overwrite
 	deon --output examples/ethics.html --overwrite

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pytest
 import subprocess
+import sys
 import itertools as it
 from click.testing import CliRunner
 
@@ -42,7 +43,7 @@ def test_cli_output(runner, checklist, tmpdir, test_format_configs, arg):
 @pytest.mark.parametrize(
     "call,format",
     it.product(
-        [["deon"], ["python", "-m", "deon"]],
+        [["deon"], [sys.executable, "-m", "deon"]],
         ["ascii", "html", "jupyter", "markdown", "rmarkdown", "rst"],
     ),
 )


### PR DESCRIPTION
- Bumps several GitHub Actions versions.
- Drops Python 3.7 from CI. Adds Python 3.11 and 3.12.
- Switches to uv for installing packages in CI. 
- Updates CLI test to use [`sys.executable`](https://docs.python.org/3/library/sys.html#sys.executable) instead of `python` so that the correct virtual environment is reliably used

Closes #172 